### PR TITLE
add `Plus Jakarta Sans` metrics

### DIFF
--- a/src/metrics/googleFonts.json
+++ b/src/metrics/googleFonts.json
@@ -6697,5 +6697,12 @@
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000
+  },
+  "Plus Jakarta Sans": {
+    "capHeight": 745,
+    "ascent": 1038,
+    "descent": -222,
+    "lineGap": 0,
+    "unitsPerEm": 1000
   }
 }


### PR DESCRIPTION
add metrics for the Google Font "Plus Jakarta Sans", which is found in [capsize](https://seek-oss.github.io/capsize/).

This is the brand font for the project I'm currently working in, so I'd love to have it :-)


Thanks!